### PR TITLE
Harsher Min Stake Checks

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -312,6 +312,11 @@ bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockF
         return error("CheckStakeKernelHash() : min age violation - nTimeBlockFrom=%d nStakeMinAge=%d nTimeTx=%d",
                      nTimeBlockFrom, nStakeMinAge, nTimeTx);
 
+    //Enforce minimum stake amount
+    if (nValueIn < Params().StakingMinInput())
+        return error("CheckStakeKernelHash() : Min Stake Input is %d, but we found %d", 
+                     Params().MinStakingInput()/COIN, nValueIn/COIN);
+    
     //grab difficulty
     uint256 bnTargetPerCoinDay;
     bnTargetPerCoinDay.SetCompact(nBits);


### PR DESCRIPTION
Last update removed 99.9% of stakes, but theres varying inputs being accepted under 12,000 FIX
Moved another check into Kernel this way aside from the wallet the core is now looking out for this